### PR TITLE
Fixed a bug for conversational_history

### DIFF
--- a/chat_with_cosmo.py
+++ b/chat_with_cosmo.py
@@ -78,6 +78,7 @@ class CosmoAgent:
                 print(cf.green("[Conversation history cleared. Chat with Cosmo!]"))
                 continue
             if user_input == "[END]":
+                self.reset_history()
                 break
             response = self.generate(situation_narrative, role_instruction, user_input)
             print(cf.blue("Cosmo: " + response))


### PR DESCRIPTION
@skywalker023 add `self.reset_history()` when `user_input=="[END]"`. Otherwise the current conversational history will accumulate to the new conversation if user taps "Y".